### PR TITLE
[UIP-1]: Advance Epoch reward distribution change

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -54,7 +54,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 50e18; // 50 U8D
+    uint256 private constant ADVANCE_INCENTIVE = 25e18; // 25 U8D
     uint256 private constant DAO_EXIT_STREAM_PERIOD = 72 hours; // 3 days of DAO streaming
 
     uint256 private constant DAO_EXIT_MAX_BOOST = uint256(-1);  // infinity - without max boost

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,12 +31,17 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // initial liquidity for uniswap pool:
-        mintToAccount(0x77FBF866BdFE6a73E1F2D8DF9F09D480a027331A, 10000e18);
     }
 
     function advance() external {
-        incentivize(msg.sender, Constants.getAdvanceIncentive());
+        if (bootstrappingAt(epoch())) {
+            uint256 bootstrappingIncentive = Constants.getAdvanceIncentive().mul(2); // with x2 bonus (50 U8D)
+            uint256 senderIncentive = bootstrappingIncentive.div(10);
+            incentivize(msg.sender, senderIncentive); // 5 U8D to sender
+            increaseSupply(bootstrappingIncentive.sub(senderIncentive)); // 45 U8D to DAO and LP Pool
+        } else {
+            incentivize(msg.sender, Constants.getAdvanceIncentive());
+        }
 
         Bonding.step();
         Regulator.step();


### PR DESCRIPTION
**Universal Improvement Proposal 1:** 
1. During the Bootstrap period the distribution of rewards for advancing epochs will be changed. 5 U8D will go to the caller (in many cases, the bots), and 45 U8D will be distributed between DAO and LP bonders (70:30).
2. After the Bootstrap period the full reward for advance will be 25 U8D and will go to the advance caller.

**Reason**
We've been seeing a battle between bots that get rewarded for advancing the epochs, which proceed to immediately the rewards at a huge price making a huge profit. Rather than letting external arbitrageurs drain this value from the ecosystem, we propose the following.

**An instance implementing these changes is deployed at :** 
[0x703657161eA4ad3975Bc6872479A45648e23CC98](https://etherscan.io/address/0x703657161ea4ad3975bc6872479a45648e23cc98)

**Voting is live in the DAO:**
https://u8d.finance/#/governance/