### PR TITLE
[UIP-3]: Fix pool reward streaming

### DIFF
--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -49,8 +49,15 @@ contract Govern is Setters, Permission, Upgradeable {
                 "Not enough stake to propose"
             );
 
-            createCandidate(candidate, Constants.getGovernancePeriod());
-            emit Proposal(candidate, msg.sender, epoch(), Constants.getGovernancePeriod());
+            uint256 governancePeriod = Constants.getGovernancePeriod();
+
+            // bootstrapping governance period is 8 times shorter (6 epochs)
+            if (bootstrappingAt(epoch())) {
+                governancePeriod = governancePeriod.div(8);
+            }
+
+            createCandidate(candidate, governancePeriod);
+            emit Proposal(candidate, msg.sender, epoch(), governancePeriod);
         }
 
         Require.that(

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -23,6 +23,7 @@ import "./Regulator.sol";
 import "./Bonding.sol";
 import "./Govern.sol";
 import "../Constants.sol";
+import "../oracle/IPool.sol";
 
 contract Implementation is State, Bonding, Market, Regulator, Govern {
     using SafeMath for uint256;
@@ -31,6 +32,12 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
+        // upgrade pool
+        IPool(pool()).upgrade(0x352bD56cBF56f192c4922C9695c25bBB48EbfE56);
+        IPool(pool()).initAfterUpgrade();
+
+        // special thanks to @Lebeda for helping
+        mintToAccount(0x75E3744f61513A016036b2F1c327eD4aA7073f73, 25e18);
     }
 
     function advance() external {

--- a/protocol/contracts/oracle/IPool.sol
+++ b/protocol/contracts/oracle/IPool.sol
@@ -18,4 +18,5 @@ pragma solidity ^0.5.17;
 
 contract IPool {
     function upgrade(address newPoolImplementation) external;
+    function initAfterUpgrade() external;
 }

--- a/protocol/contracts/oracle/Pool.sol
+++ b/protocol/contracts/oracle/Pool.sol
@@ -269,7 +269,7 @@ contract Pool is PoolSetters, Liquidity, PoolUpgradable {
 
             uint256 amountToUnstream = value.sub(staged);
             uint256 newLpReserved = unreleasedLpAmount(msg.sender).sub(amountToUnstream, "Pool: insufficient balance");
-            if (newLpReserved >= 0) {
+            if (newLpReserved > 0) {
                 setStream(
                     streamLp(msg.sender),
                     newLpReserved,

--- a/protocol/contracts/oracle/PoolGetters.sol
+++ b/protocol/contracts/oracle/PoolGetters.sol
@@ -62,12 +62,21 @@ contract PoolGetters is PoolState, StreamingGetters {
         return _state.balance.phantom;
     }
 
+    function totalRewardStreamable() public view returns (uint256) {
+        return _totalRewardStreamable;
+    }
+
     function totalRewarded() public view returns (uint256) {
-        return dollar().balanceOf(address(this)).sub(totalClaimable());
+        return dollar().balanceOf(address(this)).sub(totalClaimable()).sub(totalRewardStreamable());
     }
 
     function paused() public view returns (bool) {
         return _state.paused;
+    }
+
+    // internal getter
+    function upgradeTimestamp() internal view returns (uint256) {
+        return _upgradeTimestamp;
     }
 
     /**

--- a/protocol/contracts/oracle/PoolSetters.sol
+++ b/protocol/contracts/oracle/PoolSetters.sol
@@ -33,6 +33,18 @@ contract PoolSetters is PoolState, PoolGetters, StreamingSetters {
         _state.paused = true;
     }
 
+    function setUpgradeTimestamp() internal {
+        _upgradeTimestamp = blockTimestamp();
+    }
+
+    function incrementTotalRewardStreamable(uint256 amount) internal {
+        _totalRewardStreamable = _totalRewardStreamable.add(amount);
+    }
+
+    function decrementTotalRewardStreamable(uint256 amount, string memory reason) internal {
+        _totalRewardStreamable = _totalRewardStreamable.sub(amount, reason);
+    }
+
     /**
      * Account
      */

--- a/protocol/contracts/oracle/PoolState.sol
+++ b/protocol/contracts/oracle/PoolState.sol
@@ -61,4 +61,7 @@ contract PoolStorage {
 
 contract PoolState {
     PoolStorage.State _state;
+
+    uint256 _totalRewardStreamable;
+    uint256 _upgradeTimestamp;
 }


### PR DESCRIPTION
**Universal Improvement Proposal 3:**

- This proposal is about fixing an issue with fluctuating rewards balances showing up. This issue was found by community members that found an inconsistency between the original Empty Set Dollar logic and our novel streaming implementation.
- Minor update: not allowed to cancel all stream reserved in pool bond function (as originally done in DAO bond).
- Also implemented UIP-2.

**An new DAO instance implementing these changes is deployed at:**
[0xE620699ecD0f20c0B89029F5d51D95B14090C8CB](https://etherscan.io/address/0xe620699ecd0f20c0b89029f5d51d95b14090c8cb)

**An new Pool instance implementing these changes is deployed at:**
[0x352bD56cBF56f192c4922C9695c25bBB48EbfE56](https://etherscan.io/address/0x352bd56cbf56f192c4922c9695c25bbb48ebfe56)

We would like to give our special thanks to @Lebeda for helping analyze and find the issue. @Lebeda will be rewarded 25 U8D for this contribution. [0x75E3744f61513A016036b2F1c327eD4aA7073f73](https://etherscan.io/address/0x75E3744f61513A016036b2F1c327eD4aA7073f73)