### PR TITLE
[UIP-4]: Update protocol parameters

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -46,7 +46,7 @@ library Constants {
     uint256 private constant EPOCH_PERIOD = 1 hours;
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 48; // 48 epochs
+    uint256 private constant GOVERNANCE_PERIOD = 24; // 24 epochs
     uint256 private constant GOVERNANCE_EXPIRATION = 16; // 16 + 1 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 1e16; // 1%
@@ -54,16 +54,17 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 25e18; // 25 U8D
-    uint256 private constant DAO_EXIT_STREAM_PERIOD = 72 hours; // 3 days of DAO streaming
+    uint256 private constant ADVANCE_INCENTIVE_USD = 70e18; // 70 USD
+    uint256 private constant ADVANCE_MAX_INCENTIVE = 200e18; // 200 U8D
+    uint256 private constant DAO_EXIT_STREAM_PERIOD = 120 hours; // 5 days of DAO streaming
 
     uint256 private constant DAO_EXIT_MAX_BOOST = uint256(-1);  // infinity - without max boost
     uint256 private constant DAO_EXIT_BOOST_COEFFICIENT = 200e16; // 200% (x2) – DAO boosting coefficient for fast streaming
     uint256 private constant DAO_EXIT_BOOST_PENALTY = 25e16; // 25% – penalty for DAO stream boosting
 
     /* Pool */
-    uint256 private constant POOL_LP_EXIT_STREAM_PERIOD = 36 hours; // 1.5 days of Pool LP streaming
-    uint256 private constant POOL_REWARD_EXIT_STREAM_PERIOD = 36 hours; // 1.5 days of Pool Reward streaming
+    uint256 private constant POOL_LP_EXIT_STREAM_PERIOD = 72 hours; // 3 days of Pool LP streaming
+    uint256 private constant POOL_REWARD_EXIT_STREAM_PERIOD = 72 hours; // 3 days of Pool Reward streaming
 
     uint256 private constant POOL_EXIT_MAX_BOOST = uint256(-1);  // infinity - without max boost
     uint256 private constant POOL_EXIT_BOOST_COEFFICIENT = 200e16; // 200% (x2) – Pool boosting coefficient for fast streaming
@@ -75,7 +76,7 @@ library Constants {
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
-    uint256 private constant SUPPLY_CHANGE_DIVISOR = 24e18; // 24
+    uint256 private constant SUPPLY_CHANGE_DIVISOR = 48e18; // 48
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
     uint256 private constant NEGATIVE_SUPPLY_CHANGE_DIVISOR = 12e18; // 12
     uint256 private constant ORACLE_POOL_RATIO = 30; // 30%
@@ -140,8 +141,12 @@ library Constants {
         return GOVERNANCE_EMERGENCY_DELAY;
     }
 
-    function getAdvanceIncentive() internal pure returns (uint256) {
-        return ADVANCE_INCENTIVE;
+    function getAdvanceIncentiveUsd() internal pure returns (uint256) {
+        return ADVANCE_INCENTIVE_USD;
+    }
+
+    function getAdvanceMaxIncentive() internal pure returns (uint256) {
+        return ADVANCE_MAX_INCENTIVE;
     }
 
     /* DAO */

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -49,15 +49,8 @@ contract Govern is Setters, Permission, Upgradeable {
                 "Not enough stake to propose"
             );
 
-            uint256 governancePeriod = Constants.getGovernancePeriod();
-
-            // bootstrapping governance period is 8 times shorter (6 epochs)
-            if (bootstrappingAt(epoch())) {
-                governancePeriod = governancePeriod.div(8);
-            }
-
-            createCandidate(candidate, governancePeriod);
-            emit Proposal(candidate, msg.sender, epoch(), governancePeriod);
+            createCandidate(candidate, Constants.getGovernancePeriod());
+            emit Proposal(candidate, msg.sender, epoch(), Constants.getGovernancePeriod());
         }
 
         Require.that(

--- a/protocol/contracts/mock/MockRegulator.sol
+++ b/protocol/contracts/mock/MockRegulator.sol
@@ -28,7 +28,8 @@ contract MockRegulator is MockComptroller, Regulator {
     }
 
     function stepE() external {
-        super.step();
+        Decimal.D256 memory price = oracleCapture();
+        super.step(price);
     }
 
     function bootstrappingAt(uint256 epoch) public view returns (bool) {

--- a/protocol/contracts/oracle/IPool.sol
+++ b/protocol/contracts/oracle/IPool.sol
@@ -18,5 +18,4 @@ pragma solidity ^0.5.17;
 
 contract IPool {
     function upgrade(address newPoolImplementation) external;
-    function initAfterUpgrade() external;
 }

--- a/protocol/contracts/oracle/Pool.sol
+++ b/protocol/contracts/oracle/Pool.sol
@@ -361,11 +361,6 @@ contract Pool is PoolSetters, Liquidity, PoolUpgradable {
         upgradeTo(newPoolImplementation);
     }
 
-    // UIP-3 fix
-    function initAfterUpgrade() external onlyDao {
-        setUpgradeTimestamp();
-    }
-
     function balanceCheck() private {
         Require.that(
             univ2().balanceOf(address(this)) >= totalStaged().add(totalBonded()),


### PR DESCRIPTION
### Universal Improvement Proposal 4:

_Dear community,_

We are successfully nearing the end of the ten day bootstrap period, with almost 1.5 mil tokens circulating a market cap of more than 4 million dollars. However, the end of the bootstrap period is only the beginning of the journey for the U8D ecosystem. 

To ensure that U8D stays sustainable, and doesn't undergo the same faith as the likes of ESD and DSD, we want to propose **the following changes to the protocol:**
- Change the governance period to 24 hours.  
- Increase the inflationary divider from 24 to 48. So the formula for inflation will be (TWAP-1)/48 with maximum inflation 3% per epoch at a price of 2.44. 
- Change default streaming time to 3 days for LP and to 5 days for DAO to help smoothen out the downwards pressure from people exiting the ecosystem.
- Increase rewards for advancing epochs to 70 USDC equivalent in U8D with a maximum of 200 U8D.

An **new DAO** instance implementing these changes is deployed at:
[0xc5d34B3De92C9CCA7e6E58552CfF4F6371A5eBf8](https://etherscan.io/address/0xc5d34b3de92c9cca7e6e58552cff4f6371a5ebf8)

An **new Pool** instance implementing these changes is deployed at:
[0x64c8A67Da288C1332F3eFA672c3588D9905218B2](https://etherscan.io/address/0x64c8a67da288c1332f3efa672c3588d9905218b2)

**Voting is live in the DAO:**
https://u8d.finance/#/governance/